### PR TITLE
add quoted_status fields

### DIFF
--- a/lib/simple_tweet.rb
+++ b/lib/simple_tweet.rb
@@ -188,6 +188,9 @@ module SimpleTweet
     :lang,
     :extended_entities,
     :possibly_sensitive,
+    :quoted_status_id,
+    :quoted_status_id_str,
+    :quoted_status,
     keyword_init: true
   )
   User = ::Struct.new(


### PR DESCRIPTION
Tweetの本文に、他のtweetのuriが含まれていると生えるフィールド(他にもいろいろありそうなので、発見ベースで直していく……)。